### PR TITLE
added MTA component with logstash

### DIFF
--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -18,6 +18,8 @@ services:
           condition: on-failure
       logstash-mta:
        image: ahromis/logstash:latest
+       environment:
+        LOGSTASH_HOST: ${LOGSTASH_HOST}:5044
        hostname: logstash
        networks:
         - elk

--- a/journalbeat-docker-compose.yml
+++ b/journalbeat-docker-compose.yml
@@ -16,5 +16,25 @@ services:
           delay: 10s
         restart_policy:
           condition: on-failure
+      logstash-mta:
+       image: ahromis/logstash:latest
+       hostname: logstash
+       networks:
+        - elk
+       deploy:
+        mode: global
+        update_config:
+          parallelism: 2
+          delay: 10s
+        restart_policy:
+          condition: on-failure
+       volumes:
+        - logstash-sincedb:/usr/share/logstash/data
+        - /var/lib/docker/volumes:/log/volumes
+
+volumes:
+  logstash-sincedb:
 networks:
   journalbeat:
+  elk:
+    external: true

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,0 +1,7 @@
+FROM logstash:5.5.0-alpine
+
+RUN mkdir -p /log/volumes
+COPY logstash.conf /etc/logstash.conf
+
+ENTRYPOINT ["logstash"]
+CMD ["-f", "/etc/logstash.conf"]

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -1,0 +1,34 @@
+# Extending Logstash
+
+This directory is used to extend the logstash directory for Modernizing Traditional Applications.
+
+## Testing
+
+Many times traditional applications will log to multiple locations. Java applications are often configured to log in this way. It's possible to modernize those applications without changing the logger by leverging Go service templating that Docker provides.
+
+When launching a Tomcat application with the following parameters, Docker will create a volume that contains the container name.
+
+```
+docker service create \
+    -d \
+    --name prod-tomcat \
+    --label version=1.5 \
+    --label environment=prod \
+    --mount type=volume,src="{{.Task.Name}}",dst=/usr/local/tomcat/logs \
+    --replicas 3 \
+    tomcat:latest
+```
+
+That will create output similar to this from logstash when using this repo. The `CONTAINER_NAME` will match the output of the `stdout` stream from the container, making it easy to filter based on your container's logs.
+
+```
+{
+              "path" => "/log/volumes/prod-tomcat.2.sdfuuijyruyzoi98uwpixl5iv/_data/catalina.2017-07-05.log",
+        "@timestamp" => 2017-07-06T13:24:14.875Z,
+          "@version" => "1",
+              "host" => "logstash",
+           "message" => "05-Jul-2017 23:40:50.256 INFO [localhost-startStop-1] org.apache.catalina.startup.HostConfig.deployDirectory Deployment of web application directory [/usr/local/tomcat/webapps/docs] has finished in [47] ms",
+    "CONTAINER_NAME" => "prod-tomcat.2.sdfuuijyruyzoi98uwpixl5iv",
+         "FILE_NAME" => "catalina.2017-07-05.log"
+}
+```

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -1,0 +1,21 @@
+input {
+  file {
+    codec => "plain"
+    path => "/log/volumes/*/_data/*.log"
+    start_position => "beginning"
+  }
+}
+
+filter {
+  if [path] =~ "^\/log\/volumes\/.*" {
+    grok {
+      match => { "path" =>  "/log/volumes/%{DATA:CONTAINER_NAME}/_data/%{GREEDYDATA:FILE_NAME}" }
+    }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["elasticsearch"]
+  }
+}

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -16,6 +16,6 @@ filter {
 
 output {
   elasticsearch {
-    hosts => ["elasticsearch"]
+    hosts => ["${LOGSTASH_HOST}"]
   }
 }


### PR DESCRIPTION
- Added a new logstash service that runs globally, since it should be optional if you wish to run this component (i.e. if you run a lot of existing Java apps) I didn't include it with the other logstash service for that reason.
- Added config files and a separate directory for the logstash config, currently it's built as `ahromis/logstash:latest`